### PR TITLE
Added console executable godaddy, config support via ~/.godaddyrc

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,9 @@
+0.2.0 (2014-03-23)
+++++++++++++++++++
+
+* Added console executable godaddy
+* Added config support via ~/.godaddyrc
+
 0.1.1-0.1.6 (2013-07-12)
 ++++++++++++++++++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,14 @@ QUICKSTART
         print client.find_domains()
         client.update_dns_record('sub.example.com', '1.2.3.4')
 
+.. code-block:: bash
+
+    godaddy list
+    godaddy find example.com
+    godaddy update sub.example.com 1.2.3.4
+    godaddy delete sub.example.com 
+
+
 DOCS
 ----
 

--- a/pygodaddy/__init__.py
+++ b/pygodaddy/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.6'
-from .client import GoDaddyClient, GoDaddyAccount, LoginError
+__version__ = '0.2.0'
+from .client import GoDaddyClient, GoDaddyAccount, GoDaddyError, LoginError

--- a/pygodaddy/client.py
+++ b/pygodaddy/client.py
@@ -28,7 +28,10 @@ logger = logging.getLogger(__name__)
 
 DNSRecord = namedtuple('DNSRecord', 'index, hostname, value, ttl, host_td, points_to, rec_modified')
 
-class LoginError(Exception):
+class GoDaddyError(Exception):
+    pass
+
+class LoginError(GoDaddyError):
     pass
 
 class GoDaddyAccount(object):

--- a/pygodaddy/main.py
+++ b/pygodaddy/main.py
@@ -20,8 +20,8 @@ Options:
 """
 
 __doc__ = __doc__.format(
-  auth_args='([--account=<acct>] [--config=<cfg>] | [ (--username=<user> --password=<pass>) ])'
-  )
+    auth_args='([--account=<acct>] [--config=<cfg>] | [ (--username=<user> --password=<pass>) ])'
+    )
 
 import ConfigParser
 import docopt
@@ -29,13 +29,17 @@ import os.path
 import pygodaddy
 import sys
 
+
 DEFAULT_CONFIG_PATH = os.path.expanduser('~/.godaddyrc')
+
 
 class LoginConfigError(pygodaddy.GoDaddyError):
     pass
 
+
 class LoginAccountNameError(LoginConfigError):
     pass
+
 
 def _get_client_auth(args):
     """ finds/parses the username and password from either the args or a config file.
@@ -58,6 +62,7 @@ def _get_client_auth(args):
                 config_file_path
                 ))
     return username, password
+
 
 def _map_to_methods_and_args(client, args):
     """ maps CLI args to GoDaddyClient methods and args for separate invocation
@@ -86,6 +91,7 @@ def _map_to_methods_and_args(client, args):
             {'record_type': args['--record-type']}
             )
 
+
 def main():
     try:
         args = docopt.docopt(__doc__, version=pygodaddy.__version__)
@@ -100,9 +106,9 @@ def main():
         method, pargs, kwargs = _map_to_methods_and_args(client, args)
         result = method(*pargs, **kwargs)
         if result is True:
-            sys.exit(0) # POSIX success
+            sys.exit(0)  # POSIX success
         elif result is False:
-            sys.exit(1) # POSIX error
+            sys.exit(1)  # POSIX error
         elif isinstance(result, basestring):
             print(result)
         else:
@@ -112,6 +118,7 @@ def main():
         sys.exit(e.message)
     except docopt.DocoptLanguageError as e:
         sys.exit(e.message)
+
 
 if __name__ == '__main__':
     main()

--- a/pygodaddy/main.py
+++ b/pygodaddy/main.py
@@ -1,0 +1,117 @@
+"""
+GoDaddy DNS Client (via pygodaddy)
+
+Usage:
+  godaddy (-h | --version)
+  godaddy list {auth_args}
+  godaddy find <domain> [--record-type=<t>] {auth_args}
+  godaddy update <hostname> <value> [--record-type=<t>] [--new-record] {auth_args}
+  godaddy delete <hostname> [--record-type=<t>] {auth_args}
+
+Options:
+  -h --help             Show this screen.
+  -v --version          Show version.
+  -n --new-record       With 'update' command, creates a new DNS record
+  --record-type=<t>     DNS Record Type [Default: A]
+  --account=<acct>      Optional, account section name in ~/.godaddyrc config [Default: default]
+  --config=<cfg>        Optional, account login config file path [Default: ~/.godaddyrc]
+  --username=<user>     Optional, GoDaddy login username if not using config file
+  --password=<pass>     Optional, GoDaddy login password if not using config file
+"""
+
+__doc__ = __doc__.format(
+  auth_args='([--account=<acct>] [--config=<cfg>] | [ (--username=<user> --password=<pass>) ])'
+  )
+
+import ConfigParser
+import docopt
+import os.path
+import pygodaddy
+import sys
+
+DEFAULT_CONFIG_PATH = os.path.expanduser('~/.godaddyrc')
+
+class LoginConfigError(pygodaddy.GoDaddyError):
+    pass
+
+class LoginAccountNameError(LoginConfigError):
+    pass
+
+def _get_client_auth(args):
+    """ finds/parses the username and password from either the args or a config file.
+
+    :returns: a tuple of (username, password)
+    """
+    username, password = args['--username'], args['--password']
+    if not (username and password):
+        config_file_path = os.path.expanduser(args['--config'])
+        if not os.path.exists(config_file_path):
+            raise LoginConfigError('Login config file {0} does not exist.'.format(config_file_path))
+        try:
+            parser = ConfigParser.SafeConfigParser()
+            parser.read(config_file_path)
+            section = args['--account']
+            username, password = parser.get(section, 'username'), parser.get(section, 'password')
+        except ConfigParser.NoSectionError:
+            raise LoginAccountNameError('Account config section {0} is not found in {1}'.format(
+                repr(args['--account']),
+                config_file_path
+                ))
+    return username, password
+
+def _map_to_methods_and_args(client, args):
+    """ maps CLI args to GoDaddyClient methods and args for separate invocation
+
+    :param client: an instance of `pygodaddy.GoDaddyClient`
+    :param args: an instance of `docopt.Dict` containing parsed args
+    """
+    if args['list']:
+        return (client.find_domains, (), {})
+    elif args['find']:
+        return (
+            client.find_dns_records,
+            (args['<domain>'],),
+            {'record_type': args['--record-type']}
+            )
+    elif args['update']:
+        return (
+            client.update_dns_record,
+            (args['<hostname>'], args['<value>']),
+            {'record_type': args['--record-type'], 'new': (args['--new-record'] or False)}
+            )
+    elif args['delete']:
+        return (
+            client.delete_dns_record,
+            (args['<hostname>'],),
+            {'record_type': args['--record-type']}
+            )
+
+def main():
+    try:
+        args = docopt.docopt(__doc__, version=pygodaddy.__version__)
+        if args['--version']:
+            print(pygodaddy.__version__)
+            sys.exit(0)
+        username, password = _get_client_auth(args)
+        client = pygodaddy.GoDaddyClient()
+        client.login(username, password)
+        if not client.is_loggedin():
+            sys.exit('Incorrect username/password: "{0}"/"{1}"'.format(username, password))
+        method, pargs, kwargs = _map_to_methods_and_args(client, args)
+        result = method(*pargs, **kwargs)
+        if result is True:
+            sys.exit(0) # POSIX success
+        elif result is False:
+            sys.exit(1) # POSIX error
+        elif isinstance(result, basestring):
+            print(result)
+        else:
+            for r in result:
+                print(r)
+    except pygodaddy.GoDaddyError as e:
+        sys.exit(e.message)
+    except docopt.DocoptLanguageError as e:
+        sys.exit(e.message)
+
+if __name__ == '__main__':
+    main()

--- a/pygodaddy/main.py
+++ b/pygodaddy/main.py
@@ -11,12 +11,12 @@ Usage:
 Options:
   -h --help             Show this screen.
   -v --version          Show version.
-  -n --new-record       With 'update' command, creates a new DNS record
-  --record-type=<t>     DNS Record Type [Default: A]
-  --account=<acct>      Optional, account section name in ~/.godaddyrc config [Default: default]
-  --config=<cfg>        Optional, account login config file path [Default: ~/.godaddyrc]
-  --username=<user>     Optional, GoDaddy login username if not using config file
-  --password=<pass>     Optional, GoDaddy login password if not using config file
+  -n --new-record       With 'update' command, creates a new DNS record.
+  --record-type=<t>     DNS Record Type [Default: A].
+  --account=<acct>      Optional, account section name in ~/.godaddyrc config [Default: default].
+  --config=<cfg>        Optional, account login config file path [Default: ~/.godaddyrc].
+  --username=<user>     Optional, GoDaddy login username if not using config file.
+  --password=<pass>     Optional, GoDaddy login password if not using config file.
 """
 
 __doc__ = __doc__.format(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+docopts==0.6.1
 requests>=1.2.3
 nose>=1.3

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,9 @@ try:
 except ImportError:
     from distutils.core import setup
 
-import pygodaddy
-
 setup(
     name='pygodaddy',
-    version=pygodaddy.__version__,
+    version='0.2.0',
     description = '3rd Party Client Library for Manipulating Go Daddy DNS Records.',
     long_description=open('README.rst').read()+'\n\n'+open('HISTORY.rst').read(),
     url = 'https://github.com/observerss/pygodaddy',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,15 @@ setup(
     packages = ['pygodaddy'],
     package_data={'': ['LICENSE']},
     package_dir = {'pygodaddy':'pygodaddy'},
-    install_requires = ['requests>=1.2.3'],
+    entry_points = {
+        'console_scripts': [
+            'godaddy = pygodaddy.main:main',
+        ]
+    },
+    install_requires = [
+        'docopts==0.6.1',
+        'requests>=1.2.3'
+        ],
     license = open('LICENSE').read(),
     classifiers=(
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,11 @@ try:
 except ImportError:
     from distutils.core import setup
 
+import pygodaddy
+
 setup(
     name='pygodaddy',
-    version = '0.1.6',
+    version=pygodaddy.__version__,
     description = '3rd Party Client Library for Manipulating Go Daddy DNS Records.',
     long_description=open('README.rst').read()+'\n\n'+open('HISTORY.rst').read(),
     url = 'https://github.com/observerss/pygodaddy',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,23 @@
+"""
+GoDaddy DNS Client (via pygodaddy)
+
+Usage:
+  godaddy (-h | --version)
+  godaddy list
+  godaddy find <domain> --record-type=<t> {auth_args}
+  godaddy update <hostname> <value> --record-type=<t> [--new-record] {auth_args}
+  godaddy delete <hostname> --record-type=<t> {auth_args}
+
+Options:
+  -h --help      Show this screen.
+  --version      Show version.
+  --record-type  DNS Record Type [Default: 'A']
+  --new-record   With 'update' command, creates a new DNS record
+  --account      Optional, account section name in ~/.godaddyrc config [Default: 'default']
+  --username     Optional, GoDaddy login username if not using ~/.godaddyrc config
+  --password     Optional, GoDaddy login password if not using ~/.godaddyrc config
+"""
+
+__doc__ = __doc__.format(
+  auth_args='([--account <acct>] | [ --username=<user> --password=<pass> ])'
+  )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,141 @@
+import docopt
+import os
+import pygodaddy
+import pygodaddy.main as main
+import tempfile
+import unittest
+
+class TestArgMapping(unittest.TestCase):
+    """
+    Tests that CLI args are properly mapped to GoDaddyClient method calls
+    """
+    def setUp(self):
+        self.client = pygodaddy.GoDaddyClient()
+
+    def _test(self, arg_string, expect_method, expect_pargs, expect_kwargs):
+        args = docopt.docopt(main.__doc__, argv=arg_string)
+        method, pargs, kwargs = main._map_to_methods_and_args(self.client, args)
+        self.assertEqual(expect_method, method)
+        self.assertEqual(expect_pargs, pargs)
+        self.assertEqual(expect_kwargs, kwargs)
+
+    def test_list(self):
+        self._test('list', self.client.find_domains, (), {})
+
+    def test_find(self):
+        self._test(
+            'find example.com',
+            self.client.find_dns_records,
+            ('example.com',),
+            {'record_type': 'A'}
+            )
+        self._test(
+            'find example.com --record-type=C',
+            self.client.find_dns_records,
+            ('example.com',),
+            {'record_type': 'C'}
+            )
+
+    def test_update(self):
+        self._test(
+            'update foo.example.com 192.168.1.2',
+            self.client.update_dns_record, ('foo.example.com', '192.168.1.2'),
+            {'record_type': 'A', 'new': False}
+            )
+        self._test(
+            'update foo.example.com 192.168.1.2 --record-type=C',
+            self.client.update_dns_record, ('foo.example.com', '192.168.1.2'),
+            {'record_type': 'C', 'new': False}
+            )
+        self._test(
+            'update foo.example.com 192.168.1.2 --record-type=C --new-record',
+            self.client.update_dns_record, ('foo.example.com', '192.168.1.2'),
+            {'record_type': 'C', 'new': True}
+            )
+        self._test(
+            'update foo.example.com 192.168.1.2 -n',
+            self.client.update_dns_record, ('foo.example.com', '192.168.1.2'),
+            {'record_type': 'A', 'new': True}
+            )
+
+    def test_delete(self):
+        self._test(
+            'delete foo.example.com',
+            self.client.delete_dns_record,
+            ('foo.example.com',),
+            {'record_type': 'A'}
+            )
+        self._test(
+            'delete foo.example.com --record-type=C',
+            self.client.delete_dns_record,
+            ('foo.example.com',),
+            {'record_type': 'C'}
+            )
+
+
+class TestClientAuth(unittest.TestCase):
+
+    def _test(self, arg_string, expect_username, expect_password):
+        args = docopt.docopt(main.__doc__, argv=arg_string)
+        u, p = main._get_client_auth(args)
+        self.assertEqual((expect_username, expect_password), (u, p))
+
+    def test_client_auth(self):
+        self._test('list --username=foo --password=bar', 'foo', 'bar')
+
+    def test_client_config_default_account_name(self):
+        _, path = tempfile.mkstemp()
+        with open(path, 'w') as f:
+            f.write('\n'.join(['[default]', 'username = alibaba', 'password = opensesame']))
+        self._test('list --config={0}'.format(path), 'alibaba', 'opensesame')
+        os.remove(path)
+
+    def test_client_config_account_name_match(self):
+        _, path = tempfile.mkstemp()
+        with open(path, 'w') as f:
+            f.write('\n'.join(['[personal]', 'username = alibaba', 'password = opensesame']))
+            f.write('\n')
+            f.write('\n'.join(['[work]', 'username = milton', 'password = redstapler']))
+        self._test('list --config={0} --account=personal'.format(path), 'alibaba', 'opensesame')
+        self._test('list --config={0} --account=work'.format(path), 'milton', 'redstapler')
+        os.remove(path)
+
+    def test_client_config_account_name_mismatch(self):
+        _, path = tempfile.mkstemp()
+        with open(path, 'w') as f:
+            f.write('\n'.join(['[personal]', 'username = alibaba', 'password = opensesame']))
+        self.assertRaises(
+            main.LoginAccountNameError,
+            self._test,
+            'list --config={0} --account=work'.format(path), # acct name mismatch
+            'alibaba', 'opensesame'
+            )
+
+    def test_auth_invalids(self):
+        self.assertRaises(
+            docopt.DocoptExit,
+            self._test,
+            'list --username=foo', # missing password
+            'foo', 'bar'
+            )
+        self.assertRaises(
+            docopt.DocoptExit,
+            self._test,
+            'list --password=bar', # missing username
+            'foo', 'bar'
+            )
+        self.assertRaises(
+            docopt.DocoptExit,
+            self._test,
+            # account and username/password are mutually exclusive
+            'list --account=anything --username=foo --password=bar',
+            'foo', 'bar'
+            )
+
+    def test_config_file_does_not_exist(self):
+        self.assertRaises(
+            main.LoginConfigError,
+            self._test,
+            'list --config /tmp/idontexist',
+            '', '' # doesn't matter
+            )


### PR DESCRIPTION
Hi, thanks for your pygodaddy library, I find it very useful.

I am submitting this pull request to extend shell support in two ways:
1. `godaddy` provided as a command line executable
2. login via CLI args, `~/.godaddyrc`, or any other file path

I find it worthwhile to bump the version to 0.2.0 as this is not an iterative bug fix release.

Notes:
- license header comment blocks - let me know what you prefer, I can copy/paste license blocks from other files as a follow-up commit
- your previous unit tests can be ported to use the new config convention, but I think that should be done in a separate branch.
- at your comfort level: if you'd like to add me as a PyPi maintainer, my username is `Anthony.Wu`

– Anthony
