### PR TITLE
Fix for #7 - 

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,8 @@
+0.2.0 (2015-03-11)
+++++++++++++++++++
+
+* Added logging messages to add, delete, edit, save, and update methods
+
 0.1.9 (2015-03-11)
 ++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,12 +1,17 @@
+0.1.9 (2015-03-11)
+++++++++++++++++++
+
+* Fix _split_hostname() method (thanks to @artoleus and @sjpengelly)
+
 0.1.8 (2015-02-28)
 ++++++++++++++++++
 
-* Fix ".co.uk" type of domain(thanks to @sjpengelly)
+* Fix ".co.uk" type of domain (thanks to @sjpengelly)
 
 0.1.7 (2015-02-02)
 ++++++++++++++++++
 
-* Fix CSRF(thanks to @DanChianucci
+* Fix CSRF (thanks to @DanChianucci)
 
 0.1.1-0.1.6 (2013-07-12)
 ++++++++++++++++++++++++

--- a/pygodaddy/client.py
+++ b/pygodaddy/client.py
@@ -22,6 +22,7 @@ import requests
 import logging
 import re
 import time
+import tldextract
 
 __all__  = ['LoginError', 'GoDaddyClient', 'GoDaddyAccount']
 
@@ -201,16 +202,12 @@ class GoDaddyClient(object):
 
     def _split_hostname(self, hostname):
         """ split hostname into prefix + domain """
-        try:
-	    # using partition instead of split to account for hostnames with more than three .'s
-	    prefix, _, temp = hostname.partition('.')
-	    name, _, postfix = temp.partition('.')
-            domain = name + '.' + postfix
-        except:
-            domain = hostname
+        ext = tldextract.extract(hostname)
+        prefix = ext.subdomain
+        domain = ext.registered_domain
+        if not prefix:
             prefix = '@'
-
-        return  prefix, domain
+        return prefix, domain
 
     def _delete_record(self, index, record_type='A'):
         """ delete old record, return `True` if successful """

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ except ImportError:
 
 setup(
     name='pygodaddy',
-    version = '0.1.8',
+    version = '0.1.9',
     description = '3rd Party Client Library for Manipulating Go Daddy DNS Records.',
     long_description=open('README.rst').read()+'\n\n'+open('HISTORY.rst').read(),
     url = 'https://github.com/observerss/pygodaddy',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ except ImportError:
 
 setup(
     name='pygodaddy',
-    version = '0.1.9',
+    version = '0.2.0',
     description = '3rd Party Client Library for Manipulating Go Daddy DNS Records.',
     long_description=open('README.rst').read()+'\n\n'+open('HISTORY.rst').read(),
     url = 'https://github.com/observerss/pygodaddy',


### PR DESCRIPTION
The _split_hostname() method now uses `tldextract` to correctly split hostnames with all kinds of TLD, credit to @artoleus.