### PR TITLE
Add dependency tldextract

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=1.2.3
 nose>=1.3
+tldextract>=1.5.1

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     packages = ['pygodaddy'],
     package_data={'': ['LICENSE']},
     package_dir = {'pygodaddy':'pygodaddy'},
-    install_requires = ['requests>=1.2.3'],
+    install_requires = ['requests>=1.2.3', 'tldextract>=1.5.1'],
     license = open('LICENSE').read(),
     classifiers=(
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
pygodaddy.client.py imports tldextract, but setup.py doesn't define it
as a dependency.